### PR TITLE
Only unregister primary-nav block if using Nouveau.

### DIFF
--- a/build/bp-core/bp-core-blocks.php
+++ b/build/bp-core/bp-core-blocks.php
@@ -124,6 +124,13 @@ add_action( 'bp_core_blocks_init', __NAMESPACE__ . '\register_core_blocks', 10, 
  * @since 9.0.0
  */
 function bp_nouveau_unregister_blocks_for_post_context() {
+
+	$blocks_to_unregister = array();
+
+	if ( 'nouveau' === bp_get_theme_compat_id() ) {
+		$blocks_to_unregister[] = 'bp/primary-nav', // This Block is restricted to the Widget Block Editor.
+	}
+
 	/**
 	 * Filter here to remove Blocks from the post context.
 	 *
@@ -133,9 +140,7 @@ function bp_nouveau_unregister_blocks_for_post_context() {
 	 */
 	$blocks = apply_filters(
 		'bp_blocks_post_context_unregistered_blocks',
-		array(
-			'bp/primary-nav', // This Block is restricted to the Widget Block Editor.
-		)
+		$blocks_to_unregister
 	);
 
 	foreach ( $blocks as $block ) {


### PR DESCRIPTION
If using the legacy template pack, attempting to unregister the primary-nav block throws a notice.